### PR TITLE
Move to the SDK nuget packages

### DIFF
--- a/samples/ObjectDetector/cs/ObjectDetectorSample_NetCore3/ObjectDetectorSample_NetCore3.csproj
+++ b/samples/ObjectDetector/cs/ObjectDetectorSample_NetCore3/ObjectDetectorSample_NetCore3.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -15,24 +15,7 @@
     <PackageReference Include="Microsoft.AI.Skills.SkillInterfacePreview" Version="0.5.2.15" />
     <PackageReference Include="Microsoft.AI.Skills.Vision.ObjectDetectorPreview" Version="0.1.0.2" />
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.0-rc" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Reference Include="System.Runtime.WindowsRuntime">
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETCore\v4.5\System.Runtime.WindowsRuntime.dll</HintPath>
-    </Reference>
-    <Reference Include="Windows">
-      <HintPath>C:\Program Files (x86)\Windows Kits\10\UnionMetadata\Facade\Windows.WinMD</HintPath>
-      <IsWinMDFile>true</IsWinMDFile>
-    </Reference>
-    <Reference Include="Windows.Foundation.FoundationContract">
-      <HintPath>C:\Program Files (x86)\Windows Kits\10\References\10.0.17763.0\Windows.Foundation.FoundationContract\3.0.0.0\Windows.Foundation.FoundationContract.winmd</HintPath>
-      <IsWinMDFile>true</IsWinMDFile>
-    </Reference>
-    <Reference Include="Windows.Foundation.UniversalApiContract">
-      <HintPath>C:\Program Files (x86)\Windows Kits\10\References\10.0.17763.0\Windows.Foundation.UniversalApiContract\7.0.0.0\Windows.Foundation.UniversalApiContract.winmd</HintPath>
-      <IsWinMDFile>true</IsWinMDFile>
-    </Reference>
+    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.18362.2002-preview" />
   </ItemGroup>
 
 </Project>

--- a/samples/README.md
+++ b/samples/README.md
@@ -40,26 +40,7 @@
 - Windows 10 build 18362 with related SDK
 - [.NetCore 3.0 preview](https://dotnet.microsoft.com/download/dotnet-core/3.0) installed and enabled(follow instructions)
 
-> In the .NetCore 3.0 app project file *\<sample project>.csproj*, some assumption are made as to where the required Windows metadata files (*.winmd*) are stored on your computer (see ***HintPath*** below), double check they are correct if you encouter an error. Example of a .csproj with the aforementioned assumptions:
-```xml
-<ItemGroup>
-    <Reference Include="System.Runtime.WindowsRuntime">
-    <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETCore\v4.5\System.Runtime.WindowsRuntime.dll</HintPath>
-    </Reference>
-    <Reference Include="Windows">
-    <HintPath>C:\Program Files (x86)\Windows Kits\10\UnionMetadata\Facade\Windows.WinMD</HintPath>
-    <IsWinMDFile>true</IsWinMDFile>
-    </Reference>
-    <Reference Include="Windows.Foundation.FoundationContract">
-    <HintPath>C:\Program Files (x86)\Windows Kits\10\References\10.0.17763.0\Windows.Foundation.FoundationContract\3.0.0.0\Windows.Foundation.FoundationContract.winmd</HintPath>
-    <IsWinMDFile>true</IsWinMDFile>
-    </Reference>
-    <Reference Include="Windows.Foundation.UniversalApiContract">
-    <HintPath>C:\Program Files (x86)\Windows Kits\10\References\10.0.17763.0\Windows.Foundation.UniversalApiContract\7.0.0.0\Windows.Foundation.UniversalApiContract.winmd</HintPath>
-    <IsWinMDFile>true</IsWinMDFile>
-    </Reference>
-</ItemGroup>
-```
+> In the .NetCore 3.0 app project file *\<sample project>.csproj*, you need to ingest the [*Microsoft.Windows.SDK.Contracts* NuGet package](https://www.nuget.org/packages/Microsoft.Windows.SDK.Contracts) version 18362 or later that contains the required Windows metadata files (*.winmd*).
 
 ## Build the samples
 Open the provided solution file: ./VisionSkillsSamples.sln

--- a/samples/SentimentAnalyzerCustomSkill/cs/Apps/FaceSentimentAnalysisApp_.NETCore3.0/FaceSentimentAnalysisApp_.NETCore3.0.csproj
+++ b/samples/SentimentAnalyzerCustomSkill/cs/Apps/FaceSentimentAnalysisApp_.NETCore3.0/FaceSentimentAnalysisApp_.NETCore3.0.csproj
@@ -10,24 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Contoso.FaceSentimentAnalyzer_CPP" Version="0.0.0.6" />
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.0-rc" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.Runtime.WindowsRuntime">
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETCore\v4.5\System.Runtime.WindowsRuntime.dll</HintPath>
-    </Reference>
-    <Reference Include="Windows">
-      <HintPath>C:\Program Files (x86)\Windows Kits\10\UnionMetadata\Facade\Windows.WinMD</HintPath>
-      <IsWinMDFile>true</IsWinMDFile>
-    </Reference>
-    <Reference Include="Windows.Foundation.FoundationContract">
-      <HintPath>C:\Program Files (x86)\Windows Kits\10\References\10.0.17763.0\Windows.Foundation.FoundationContract\3.0.0.0\Windows.Foundation.FoundationContract.winmd</HintPath>
-      <IsWinMDFile>true</IsWinMDFile>
-    </Reference>
-    <Reference Include="Windows.Foundation.UniversalApiContract">
-      <HintPath>C:\Program Files (x86)\Windows Kits\10\References\10.0.17763.0\Windows.Foundation.UniversalApiContract\7.0.0.0\Windows.Foundation.UniversalApiContract.winmd</HintPath>
-      <IsWinMDFile>true</IsWinMDFile>
-    </Reference>
+	<PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.18362.2002-preview" />
   </ItemGroup>
 
 </Project>

--- a/samples/SkeletalDetector/cs/SkeletalDetectorSample_NetCore3/SkeletalDetectorSample_NetCore3.csproj
+++ b/samples/SkeletalDetector/cs/SkeletalDetectorSample_NetCore3/SkeletalDetectorSample_NetCore3.csproj
@@ -18,21 +18,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <Reference Include="System.Runtime.WindowsRuntime">
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETCore\v4.5\System.Runtime.WindowsRuntime.dll</HintPath>
-    </Reference>
-    <Reference Include="Windows">
-      <HintPath>C:\Program Files (x86)\Windows Kits\10\UnionMetadata\Facade\Windows.WinMD</HintPath>
-      <IsWinMDFile>true</IsWinMDFile>
-    </Reference>
-    <Reference Include="Windows.Foundation.FoundationContract">
-      <HintPath>C:\Program Files (x86)\Windows Kits\10\References\10.0.17763.0\Windows.Foundation.FoundationContract\3.0.0.0\Windows.Foundation.FoundationContract.winmd</HintPath>
-      <IsWinMDFile>true</IsWinMDFile>
-    </Reference>
-    <Reference Include="Windows.Foundation.UniversalApiContract">
-      <HintPath>C:\Program Files (x86)\Windows Kits\10\References\10.0.17763.0\Windows.Foundation.UniversalApiContract\7.0.0.0\Windows.Foundation.UniversalApiContract.winmd</HintPath>
-      <IsWinMDFile>true</IsWinMDFile>
-    </Reference>
+    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.18362.2002-preview" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The SDK nuget package will make referencing contracts from win32 & net apps simpler and avoid common mistakes.