### PR TITLE
SkeletalDetector: fix mismatch in results when using the GPU vs the CPU

### DIFF
--- a/samples/SkeletalDetector/cpp/SkeletalDetectorSample_Desktop/SkeletalDetectorSample_Desktop.vcxproj
+++ b/samples/SkeletalDetector/cpp/SkeletalDetectorSample_Desktop/SkeletalDetectorSample_Desktop.vcxproj
@@ -149,8 +149,8 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\packages\Microsoft.VCRTForwarders.140.1.0.0-rc\build\native\Microsoft.VCRTForwarders.140.targets" Condition="Exists('..\..\..\packages\Microsoft.VCRTForwarders.140.1.0.0-rc\build\native\Microsoft.VCRTForwarders.140.targets')" />
     <Import Project="..\..\..\packages\Microsoft.AI.Skills.SkillInterfacePreview.0.6.0\build\native\Microsoft.AI.Skills.SkillInterfacePreview.targets" Condition="Exists('..\..\..\packages\Microsoft.AI.Skills.SkillInterfacePreview.0.6.0\build\native\Microsoft.AI.Skills.SkillInterfacePreview.targets')" />
-    <Import Project="..\..\..\packages\Microsoft.AI.Skills.Vision.SkeletalDetectorPreview.0.1.0.3\build\native\Microsoft.AI.Skills.Vision.SkeletalDetectorPreview.targets" Condition="Exists('..\..\..\packages\Microsoft.AI.Skills.Vision.SkeletalDetectorPreview.0.1.0.3\build\native\Microsoft.AI.Skills.Vision.SkeletalDetectorPreview.targets')" />
     <Import Project="..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\..\packages\Microsoft.AI.Skills.Vision.SkeletalDetectorPreview.0.1.0.4\build\native\Microsoft.AI.Skills.Vision.SkeletalDetectorPreview.targets" Condition="Exists('..\..\..\packages\Microsoft.AI.Skills.Vision.SkeletalDetectorPreview.0.1.0.4\build\native\Microsoft.AI.Skills.Vision.SkeletalDetectorPreview.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -158,8 +158,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\packages\Microsoft.VCRTForwarders.140.1.0.0-rc\build\native\Microsoft.VCRTForwarders.140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.VCRTForwarders.140.1.0.0-rc\build\native\Microsoft.VCRTForwarders.140.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\Microsoft.AI.Skills.SkillInterfacePreview.0.6.0\build\native\Microsoft.AI.Skills.SkillInterfacePreview.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.AI.Skills.SkillInterfacePreview.0.6.0\build\native\Microsoft.AI.Skills.SkillInterfacePreview.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.AI.Skills.Vision.SkeletalDetectorPreview.0.1.0.3\build\native\Microsoft.AI.Skills.Vision.SkeletalDetectorPreview.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.AI.Skills.Vision.SkeletalDetectorPreview.0.1.0.3\build\native\Microsoft.AI.Skills.Vision.SkeletalDetectorPreview.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.AI.Skills.Vision.SkeletalDetectorPreview.0.1.0.4\build\native\Microsoft.AI.Skills.Vision.SkeletalDetectorPreview.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.AI.Skills.Vision.SkeletalDetectorPreview.0.1.0.4\build\native\Microsoft.AI.Skills.Vision.SkeletalDetectorPreview.targets'))" />
   </Target>
 </Project>

--- a/samples/SkeletalDetector/cpp/SkeletalDetectorSample_Desktop/packages.config
+++ b/samples/SkeletalDetector/cpp/SkeletalDetectorSample_Desktop/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AI.Skills.SkillInterfacePreview" version="0.6.0" targetFramework="native" />
-  <package id="Microsoft.AI.Skills.Vision.SkeletalDetectorPreview" version="0.1.0.3" targetFramework="native" />
+  <package id="Microsoft.AI.Skills.Vision.SkeletalDetectorPreview" version="0.1.0.4" targetFramework="native" />
   <package id="Microsoft.VCRTForwarders.140" version="1.0.0-rc" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.190730.2" targetFramework="native" />
 </packages>

--- a/samples/SkeletalDetector/cs/SkeletalDetectorSample_NetCore3/SkeletalDetectorSample_NetCore3.csproj
+++ b/samples/SkeletalDetector/cs/SkeletalDetectorSample_NetCore3/SkeletalDetectorSample_NetCore3.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AI.Skills.SkillInterfacePreview" Version="0.6.0" />
-    <PackageReference Include="Microsoft.AI.Skills.Vision.SkeletalDetectorPreview" Version="0.1.0.3" />
+    <PackageReference Include="Microsoft.AI.Skills.Vision.SkeletalDetectorPreview" Version="0.1.0.4" />
 	<PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.0-rc" />
   </ItemGroup>
   

--- a/samples/SkeletalDetector/cs/SkeletalDetectorSample_UWP/SkeletalDetectorSample_UWP.csproj
+++ b/samples/SkeletalDetector/cs/SkeletalDetectorSample_UWP/SkeletalDetectorSample_UWP.csproj
@@ -197,7 +197,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AI.Skills.Vision.SkeletalDetectorPreview">
-      <Version>0.1.0.3</Version>
+      <Version>0.1.0.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.8</Version>


### PR DESCRIPTION
update dependencies to use latest version of the SkeletalDetector skill that fixes mismatch in results when using the GPU vs the CPU